### PR TITLE
fix(numbers): reject 0 in parser instead of Ok-then-panic

### DIFF
--- a/ainu-utils/src/numbers/expr.rs
+++ b/ainu-utils/src/numbers/expr.rs
@@ -30,8 +30,8 @@ impl ToString for Expr {
 }
 
 pub fn parse(input: i32) -> Result<Expr, String> {
-    if input < 0 || 100 < input {
-        return Err("Input must be between 0 and 100".to_string());
+    if input < 1 || 100 < input {
+        return Err("Input must be between 1 and 100".to_string());
     }
 
     if input <= 10 || input == 20 {

--- a/ainu-utils/src/numbers/expr_test.rs
+++ b/ainu-utils/src/numbers/expr_test.rs
@@ -26,3 +26,10 @@ fn test_subtraction() {
     let expr = parse(90).unwrap();
     assert_eq!(expr.to_string(), "wan easiknehotne");
 }
+
+#[test]
+fn test_out_of_range() {
+    assert!(parse(0).is_err());
+    assert!(parse(-1).is_err());
+    assert!(parse(101).is_err());
+}


### PR DESCRIPTION
`numbers::parse(0)` accepted 0 and returned `Ok(Expr::Int(0))`. The failure surfaced one call later, inside `Expr::to_string()`, which has no arm for 0 and hits `panic!("Invalid integer for Ainu number: 0")` — Ainu counting starts at 1 and has no word for zero.

The lower bound moves from `0` to `1`, so 0 is rejected at the boundary where the range is already checked, and the error message matches the range it enforces.

Recursion is unaffected: `parse` only recurses on `ones` and `tens`, and by then the `input % 20 == 0` and `input % 20 == 10` branches have consumed every multiple of 10, so `ones` is always 1–9.

`test_out_of_range` covers 0 alongside `-1` and `101`.
