### PR TITLE
fix(kana): graceful fallback for invalid CV combinations instead of panicking

### DIFF
--- a/ainu-utils/src/kana/kana_map_cv.rs
+++ b/ainu-utils/src/kana/kana_map_cv.rs
@@ -1,5 +1,6 @@
 pub fn map_cv(c: &char, v: &char) -> String {
-    let value = match format!("{}{}", c, v).as_str() {
+    let syllable = format!("{}{}", c, v);
+    let value = match syllable.as_str() {
         "ka" => "カ",
         "ki" => "キ",
         "ku" => "ク",
@@ -82,7 +83,10 @@ pub fn map_cv(c: &char, v: &char) -> String {
         "wi" => "ウィ",
         "we" => "ウェ",
         "wo" => "ウォ",
-        _ => unreachable!(),
+        // ti/yi/wu are not Ainu syllables; they never occur in valid input.
+        // Unknown combinations return the romaji syllable unchanged, so the
+        // caller keeps the whole word in Latin instead of panicking.
+        _ => return syllable,
     };
 
     value.to_string()

--- a/ainu-utils/src/kana/kana_test.rs
+++ b/ainu-utils/src/kana/kana_test.rs
@@ -196,3 +196,13 @@ fn test_rollback() {
         "Copyright　Mojang　AB.　イテキ　エイメㇰ　ヤン！"
     )
 }
+
+#[test]
+fn test_invalid_syllables_do_not_panic() {
+    // ti/yi/wu are not Ainu syllables. Unknown CV combinations must fall back
+    // to keeping the word in Latin rather than panicking.
+    assert_eq!(transliterate_to_kana("tite"), "tite");
+    assert_eq!(transliterate_to_kana("wuye"), "wuye");
+    // valid Ainu alongside still converts
+    assert_eq!(transliterate_to_kana("kamuy"), "カムイ");
+}


### PR DESCRIPTION
Replaces the previous attempt (#22, closed) which wrongly invented kana
for `ti`/`yi`/`wu`.

**These are not valid Ainu syllables** and never occur in real input
(corpus: `ti`=3 transcription artifacts, `yi`=0, `wu`=0). The original
`unreachable!()` correctly encoded that invariant — the only real defect
was panicking on invalid/non-Ainu input.

**Fix:** unknown consonant+vowel combinations now return the romaji
syllable unchanged. Because the result then still contains ASCII letters,
the caller (`transliterate_to_kana`) keeps the whole word in Latin rather
than crashing — a safe, non-destructive fallback.

Adds a regression test covering invalid syllables.

- [x] `cargo test --lib`: 52 passed, 0 failed
- [x] No invented kana mappings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid romaji combinations no longer cause transliteration failures.
  * Unrecognized syllables are preserved as entered instead of triggering an error.
  * Valid Ainu words continue to be converted correctly.

* **Tests**
  * Added coverage confirming invalid inputs remain unchanged and do not cause crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->